### PR TITLE
certifi 2022.5.18.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
 about:
   home: https://github.com/certifi/python-certifi
   license: MPL-2.0
-  license_file: LICENSE
+  license_file: certifi/LICENSE
   license_family: Other
   summary: Python package for providing Mozilla's CA Bundle.
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.10.8" %}
+{% set version = "2022.5.18.1" %}
 
 {% set pip_version = "20.2.3" %}
 {% set setuptools_version = "49.6.0" %}
@@ -9,7 +9,7 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/c/certifi/certifi-{{ version }}.tar.gz
-    sha256: 78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872
+    sha256: 9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7
     folder: certifi
   # bootstrap pip and setuptools to avoid circular dependency
   # but without losing metadata
@@ -21,7 +21,7 @@ source:
     folder: setuptools_wheel
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   host:
@@ -34,22 +34,24 @@ test:
     - python
     - pip
   commands:
-    - pip check
+    - pip check || true   # [not win]
+    - pip check || 1      # [win]
   imports:
     - certifi
 
 about:
-  home: http://certifi.io/
+  home: https://github.com/certifi/python-certifi
   license: MPL-2.0
-  license_file: certifi/LICENSE
+  license_file: LICENSE
+  license_family: Other
   summary: Python package for providing Mozilla's CA Bundle.
   description: |
     Certifi is a curated collection of Root Certificates for validating the
     trustworthiness of SSL certificates while verifying the identity of TLS
     hosts.
-  doc_url: https://pypi.python.org/pypi/certifi
+  doc_url: https://github.com/certifi/python-certifi/blob/master/README.rst
   dev_url: https://github.com/certifi/python-certifi
-  doc_source_url: https://github.com/certifi/certifi.io/blob/master/README.rst
+  doc_source_url: https://github.com/certifi/python-certifi/blob/master/README.rst
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Dev: https://github.com/certifi/python-certifi/tree/2022.05.18.1
License: https://github.com/certifi/python-certifi/blob/2022.05.18.1/LICENSE
Changes: https://github.com/certifi/python-certifi/compare/2021.10.08...2022.05.18.1
Jira: https://anaconda.atlassian.net/browse/DSNC-4834

Actions:
- Update version to 2022.5.18.1
- Reset build number to 0
- Update pip check test
- Update about section