### PR TITLE
certifi 2022.6.15

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ build:
 requirements:
   host:
     - python
+    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2022.5.18.1" %}
+{% set version = "2022.6.15" %}
 
 {% set pip_version = "20.2.3" %}
 {% set setuptools_version = "49.6.0" %}
@@ -9,7 +9,7 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/c/certifi/certifi-{{ version }}.tar.gz
-    sha256: 9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7
+    sha256: 84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d
     folder: certifi
   # bootstrap pip and setuptools to avoid circular dependency
   # but without losing metadata
@@ -22,6 +22,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
 
 requirements:
   host:
@@ -31,7 +32,6 @@ requirements:
 
 test:
   requires:
-    - python
     - pip
   commands:
     - pip check || true   # [not win]


### PR DESCRIPTION
License: https://github.com/certifi/python-certifi/blob/2022.06.15/LICENSE
Changes: https://github.com/certifi/python-certifi/compare/2022.05.18.1...2022.06.15
Requirements: https://github.com/certifi/python-certifi/blob/2022.06.15/setup.py

Actions:
1. Skip py<36
2. Remove python from test/requires