### PR TITLE
Updating version and hash.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2023.5.7" %}
+{% set version = "2023.7.22" %}
 
 {% set pip_version = "20.2.3" %}
 {% set setuptools_version = "49.6.0" %}
@@ -9,7 +9,7 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/c/certifi/certifi-{{ version }}.tar.gz
-    sha256: 0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7
+    sha256: 539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082
     folder: certifi
   # bootstrap pip and setuptools to avoid circular dependency
   # but without losing metadata

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,3 +61,6 @@ extra:
     - sigmavirus24
     - ocefpaf
     - mingwandroid
+  skip-lints:
+    # As we are bootstrapping this build we do not require python build tools
+    - missing_python_build_tool


### PR DESCRIPTION
https://github.com/certifi/python-certifi/compare/2023.05.07..2023.07.22

- Updated version
- Updated hash
- Squelch linter check because we bootstrap the certifi build due to circular dependencies