### PR TITLE
update to 2024.2.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2023.11.17" %}
+{% set version = "2024.2.2" %}
 
 {% set pip_version = "23.2.1" %}
 {% set setuptools_version = "68.2.2" %}
@@ -9,7 +9,7 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/c/certifi/certifi-{{ version }}.tar.gz
-    sha256: 9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1
+    sha256: 0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f
     folder: certifi
   # bootstrap pip and setuptools to avoid circular dependency
   # but without losing metadata


### PR DESCRIPTION
Changes:
- Update to 2024.2.2

https://github.com/certifi/python-certifi/tree/2024.02.02
https://github.com/certifi/python-certifi/compare/2023.11.17...2024.02.02