### PR TITLE
certifi 2024.7.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2024.6.2" %}
+{% set version = "2024.7.4" %}
 
 {% set pip_version = "23.2.1" %}
 {% set setuptools_version = "68.2.2" %}
@@ -9,7 +9,7 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/c/certifi/certifi-{{ version }}.tar.gz
-    sha256: 3cd43f1c6fa7dedc5899d69d3ad0398fd018ad1a17fba83ddaf78aa46c747516
+    sha256: 5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b
     folder: certifi
   # bootstrap pip and setuptools to avoid circular dependency
   # but without losing metadata
@@ -34,12 +34,12 @@ requirements:
     - python
 
 test:
+  imports:
+    - certifi
   requires:
     - pip
   commands:
     - pip check
-  imports:
-    - certifi
 
 about:
   home: https://certifi.io/


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5257](https://anaconda.atlassian.net/browse/PKG-5257) 
- [Upstream repository](https://github.com/certifi/python-certifi/tree/2024.07.04)
- Requirements: https://github.com/certifi/python-certifi/blob/2024.07.04/setup.py

### Explanation of changes:

- No changes

### Notes:

- update certifi to 2024.7.4 due to general security consideration

[PKG-5257]: https://anaconda.atlassian.net/browse/PKG-5257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ