### PR TITLE
Updated to 2024.8.30

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2024.7.4" %}
+{% set version = "2024.8.30" %}
 
 {% set pip_version = "23.2.1" %}
 {% set setuptools_version = "68.2.2" %}
@@ -9,7 +9,7 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/c/certifi/certifi-{{ version }}.tar.gz
-    sha256: 5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b
+    sha256: bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9
     folder: certifi
   # bootstrap pip and setuptools to avoid circular dependency
   # but without losing metadata


### PR DESCRIPTION
certifi 2024.8.30

**Destination channel:** defaults

### Links

- [PKG-5620](https://anaconda.atlassian.net/browse/PKG-5620)
- [Upstream repository](https://github.com/certifi/python-certifi/tree/2024.08.30)
- [Upstream changelog/diff](https://github.com/certifi/python-certifi/compare/2024.07.04...2024.08.30)


[PKG-5620]: https://anaconda.atlassian.net/browse/PKG-5620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ