### PR TITLE
certifi 2024.12.14

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
-{% set version = "2024.8.30" %}
+{% set version = "2024.12.14" %}
 
-{% set pip_version = "23.2.1" %}
-{% set setuptools_version = "68.2.2" %}
+{% set pip_version = "24.3.1" %}
+{% set setuptools_version = "75.6.0" %}
 
 package:
   name: certifi
@@ -9,17 +9,17 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/c/certifi/certifi-{{ version }}.tar.gz
-    sha256: bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9
+    sha256: b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db
     folder: certifi
   # bootstrap pip and setuptools to avoid circular dependency
   # but without losing metadata
   # Please note when using conda-build locally, may get following error: certifi cannot depend on itself
   # Try pushing and refer to Prefect logs
   - url: https://pypi.io/packages/py3/p/pip/pip-{{ pip_version }}-py3-none-any.whl
-    sha256: 7ccf472345f20d35bdc9d1841ff5f313260c2c33fe417f48c30ac46cccabf5be
+    sha256: 3790624780082365f47549d032f3770eeb2b1e8bd1f7b2e02dace1afa361b4ed
     folder: pip_wheel
   - url: https://pypi.io/packages/py3/s/setuptools/setuptools-{{ setuptools_version }}-py3-none-any.whl
-    sha256: b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a
+    sha256: ce74b49e8f7110f9bf04883b730f4765b774ef3ef28f722cce7c273d253aaf7d
     folder: setuptools_wheel
 
 build:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6613](https://anaconda.atlassian.net/browse/PKG-6613)
- [Upstream repository](https://github.com/certifi/python-certifi/tree/2024.12.14)

### Explanation of changes:

- Update version(s)


[PKG-6613]: https://anaconda.atlassian.net/browse/PKG-6613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ