### PR TITLE
certifi 2025.06.15

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2025.4.26" %}
+{% set version = "2025.6.15" %}
 
 {% set pip_version = "24.3.1" %}
 {% set setuptools_version = "75.6.0" %}
@@ -9,7 +9,7 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/c/certifi/certifi-{{ version }}.tar.gz
-    sha256: 0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6
+    sha256: d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b
     folder: certifi
   # bootstrap pip and setuptools to avoid circular dependency
   # but without losing metadata


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-8424](https://anaconda.atlassian.net/browse/PKG-8424) 
- [Upstream repository](https://github.com/certifi/python-certifi/tree/2025.06.15)

### Explanation of changes:

- Set new version number and sha256


[PKG-8424]: https://anaconda.atlassian.net/browse/PKG-8424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ