### PR TITLE
certifi 2025.7.14 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,17 @@
-{% set version = "2025.6.15" %}
+{% set name = "certifi" %}
+{% set version = "2025.7.14" %}
 
 {% set pip_version = "24.3.1" %}
 {% set setuptools_version = "75.6.0" %}
 
 package:
-  name: certifi
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  - url: https://pypi.io/packages/source/c/certifi/certifi-{{ version }}.tar.gz
-    sha256: d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b
-    folder: certifi
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995
+    folder: {{ name }}
   # bootstrap pip and setuptools to avoid circular dependency
   # but without losing metadata
   # Please note when using conda-build locally, may get following error: certifi cannot depend on itself
@@ -24,7 +25,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
+  skip: True  # [py<37]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,8 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995
+  - url: https://github.com/certifi/python-certifi/archive/refs/tags/2025.07.14.tar.gz
+    sha256: 89734fb727880c3ddc37ad526b6de23159188c41468d6d5a0fab92642688bd46
     folder: {{ name }}
   # bootstrap pip and setuptools to avoid circular dependency
   # but without losing metadata
@@ -35,12 +35,16 @@ requirements:
     - python
 
 test:
+  source_files:
+    - certifi/certifi/tests
   imports:
     - certifi
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -vv certifi/certifi/tests
 
 about:
   home: https://certifi.io/


### PR DESCRIPTION
certifi 2025.7.14 

**Destination channel:** Defaults

### Links

- [PKG-8871]
- dev_url:        https://github.com/certifi/python-certifi/tree/2025.07.14
- conda_forge:    https://github.com/conda-forge/certifi-feedstock
- pypi:           https://pypi.org/project/certifi/2025.7.14
- pypi inspector: https://inspector.pypi.io/project/certifi/2025.7.14

### Explanation of changes:

- new version number


[PKG-8871]: https://anaconda.atlassian.net/browse/PKG-8871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ