### PR TITLE
Upgrade to certifi v2025.10.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "certifi" %}
-{% set version = "2025.8.3" %}
+{% set version = "2025.10.5" %}
 
 {% set pip_version = "24.3.1" %}
 {% set setuptools_version = "75.6.0" %}
@@ -9,8 +9,8 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/certifi/python-certifi/archive/refs/tags/2025.08.03.tar.gz
-    sha256: fdbe80c4c92fc99449759a62e06508667eabbdb04f1ace6010b88028de8d2c97
+  - url: https://github.com/certifi/python-certifi/archive/refs/tags/2025.10.05.tar.gz
+    sha256: c7016bd510a9b54bf558bd9e3dd40a78688490990c7861234f367219f6ec2ccf
     folder: {{ name }}
   # bootstrap pip and setuptools to avoid circular dependency
   # but without losing metadata


### PR DESCRIPTION
certifi 2025.10.5

**Destination channel:** defaults

### Links

- [10080](https://anaconda.atlassian.net/browse/PKG-10050) 
- [Upstream repository](https://github.com/certifi/python-certifi)
- [Upstream changelog/diff](https://wiki.mozilla.org/CA/Included_Certificates)
- Relevant dependency PRs:
  - N/A

### Explanation of changes:

- Upgrade upstream package version to v2025.10.5
