### PR TITLE
v2026.01.04

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "certifi" %}
 {% set version = "2026.01.04" %}
+{% set normalized_version = ".".join(version.split(".") | map("int") | map("string")) %}
 {% set pip_version = "24.3.1" %}
 {% set setuptools_version = "75.6.0" %}
 
@@ -42,7 +43,7 @@ test:
     - pytest
   commands:
     - pip check
-    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ normalized_version }}')"
     - pytest -vv certifi/certifi/tests
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "certifi" %}
-{% set version = "2025.11.12" %}
+{% set version = "2026.01.04" %}
 {% set pip_version = "24.3.1" %}
 {% set setuptools_version = "75.6.0" %}
 
@@ -9,7 +9,7 @@ package:
 
 source:
   - url: https://github.com/certifi/python-certifi/archive/refs/tags/{{ version }}.tar.gz
-    sha256: 3e67679bfbd220da166ee43339f498b605cfa0e836383f2e7b4da2d68364c0f2
+    sha256: bd68260257cad030f8b0851f6c50adcfb3fac0e1088aae39cbe28e8bbd9a0453
     folder: {{ name }}
   # bootstrap pip and setuptools to avoid circular dependency
   # but without losing metadata


### PR DESCRIPTION
certifi 2026.01.04

**Destination channel:** defaults

### Links

- [PKG-11763](https://anaconda.atlassian.net/browse/PKG-11763) 
- [Upstream repository](https://github.com/certifi/python-certifi/tree/2026.01.04)
- [Upstream changelog/diff](https://github.com/certifi/python-certifi/releases/tag/2026.01.04)


[PKG-11763]: https://anaconda.atlassian.net/browse/PKG-11763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ